### PR TITLE
[sc-330785][box-com] Adds supported Python versions 3.13, 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.4.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.13, 3.14
+
 ## Version 1.3.0 - Feature release - 2026/04
 
 - Adding OAuth preset for SSO authentication

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,15 +1,17 @@
 {
-    "acceptedPythonInterpreters": [
-        "PYTHON36",
-        "PYTHON37",
-        "PYTHON38",
-        "PYTHON39",
-        "PYTHON310",
-        "PYTHON311",
-        "PYTHON312"
-    ],
-    "corePackagesSet": "AUTO",
-    "forceConda": false,
-    "installCorePackages": true,
-    "installJupyterSupport": false
+  "acceptedPythonInterpreters": [
+    "PYTHON36",
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
+  "corePackagesSet": "AUTO",
+  "forceConda": false,
+  "installCorePackages": true,
+  "installJupyterSupport": false
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,15 +1,18 @@
 {
-    "id": "box-com",
-    "version": "1.3.0",
-    "meta": {
-        "label": "Box.com",
-        "description": "Read and write data from/to your Box.com account",
-        "author": "Dataiku (Alex Bourret)",
-        "icon": "icon-cloud",
-        "category": "Productivity",
-        "tags": ["Connector", "Productivity"],
-        "url": "https://doc.dataiku.com/dss/latest/connecting/application-connectors/box-com.html",
-        "licenseInfo": "Apache Software License",
-        "supportLevel": "NOT_SUPPORTED"
-    }
+  "id": "box-com",
+  "version": "1.4.0",
+  "meta": {
+    "label": "Box.com",
+    "description": "Read and write data from/to your Box.com account",
+    "author": "Dataiku (Alex Bourret)",
+    "icon": "icon-cloud",
+    "category": "Productivity",
+    "tags": [
+      "Connector",
+      "Productivity"
+    ],
+    "url": "https://doc.dataiku.com/dss/latest/connecting/application-connectors/box-com.html",
+    "licenseInfo": "Apache Software License",
+    "supportLevel": "NOT_SUPPORTED"
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: `NOT_SUPPORTED`
- Added supported Python versions: `3.13, 3.14`
- Bumped plugin version: `1.4.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅